### PR TITLE
feat: redefinição de senha de médico pelo gestor

### DIFF
--- a/frontend/src/declarations.d.ts
+++ b/frontend/src/declarations.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/frontend/src/layout/GestorMedicos/BodyGestorMedicos.tsx
+++ b/frontend/src/layout/GestorMedicos/BodyGestorMedicos.tsx
@@ -14,6 +14,15 @@ interface ModalDeleteState {
   erro: string | null;
 }
 
+interface ModalSenhaState {
+  open: boolean;
+  medico: MedicoResumo | null;
+  senha: string;
+  loading: boolean;
+  erro: string | null;
+  sucesso: boolean;
+}
+
 const MODAL_INICIAL: ModalDeleteState = {
   open: false,
   medico: null,
@@ -22,11 +31,26 @@ const MODAL_INICIAL: ModalDeleteState = {
   erro: null,
 };
 
+const MODAL_SENHA_INICIAL: ModalSenhaState = {
+  open: false,
+  medico: null,
+  senha: '',
+  loading: false,
+  erro: null,
+  sucesso: false,
+};
+
+function gerarSenhaAleatoria(): string {
+  const chars = 'ABCDEFGHJKMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789@#$!';
+  return Array.from({ length: 12 }, () => chars[Math.floor(Math.random() * chars.length)]).join('');
+}
+
 const BodyGestorMedicos: React.FC = () => {
   const [medicos, setMedicos] = useState<MedicoResumo[]>([]);
   const [loading, setLoading] = useState(true);
   const [desativados, setDesativados] = useState<Set<string>>(new Set());
   const [modal, setModal] = useState<ModalDeleteState>(MODAL_INICIAL);
+  const [modalSenha, setModalSenha] = useState<ModalSenhaState>(MODAL_SENHA_INICIAL);
   const [busca, setBusca] = useState('');
 
   useEffect(() => {
@@ -89,6 +113,38 @@ const BodyGestorMedicos: React.FC = () => {
       fecharModal();
     } catch {
       setModal(m => ({ ...m, loading: false, erro: 'Erro de conexão. Tente novamente.' }));
+    }
+  }
+
+  function abrirModalSenha(medico: MedicoResumo) {
+    setModalSenha({ ...MODAL_SENHA_INICIAL, open: true, medico, senha: gerarSenhaAleatoria() });
+  }
+
+  function fecharModalSenha() {
+    setModalSenha(MODAL_SENHA_INICIAL);
+  }
+
+  async function confirmarResetarSenha() {
+    if (!modalSenha.medico) return;
+    setModalSenha(m => ({ ...m, loading: true, erro: null }));
+    const token = getGestorToken();
+    try {
+      const res = await fetch('/api/auth/resetar-senha', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ id: modalSenha.medico.id, novaSenha: modalSenha.senha }),
+      });
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}));
+        setModalSenha(m => ({ ...m, loading: false, erro: d.error || 'Erro ao redefinir senha.' }));
+        return;
+      }
+      setModalSenha(m => ({ ...m, loading: false, sucesso: true }));
+    } catch {
+      setModalSenha(m => ({ ...m, loading: false, erro: 'Erro de conexão. Tente novamente.' }));
     }
   }
 
@@ -229,6 +285,15 @@ const BodyGestorMedicos: React.FC = () => {
                             )}
                           </button>
                           <button
+                            className="gmed__btn-action gmed__btn-action--senha"
+                            title="Redefinir senha"
+                            onClick={() => abrirModalSenha(m)}
+                          >
+                            <svg viewBox="0 0 24 24" fill="currentColor" width="16" height="16" aria-hidden="true">
+                              <path d="M18 8h-1V6A5 5 0 007 6v2H6a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V10a2 2 0 00-2-2zm-6 9a2 2 0 110-4 2 2 0 010 4zm3.1-9H8.9V6a3.1 3.1 0 016.2 0v2z"/>
+                            </svg>
+                          </button>
+                          <button
                             className="gmed__btn-action gmed__btn-action--delete"
                             title="Deletar médico"
                             onClick={() => abrirModalDelete(m)}
@@ -250,6 +315,68 @@ const BodyGestorMedicos: React.FC = () => {
           </>
         )}
       </section>
+
+      {modalSenha.open && modalSenha.medico && (
+        <div className="gmed__modal-overlay" onClick={fecharModalSenha}>
+          <div className="gmed__modal" onClick={e => e.stopPropagation()}>
+            {modalSenha.sucesso ? (
+              <>
+                <h2 className="gmed__modal-title">Senha redefinida!</h2>
+                <p className="gmed__modal-desc">
+                  A nova senha de <strong>{modalSenha.medico.nome} {modalSenha.medico.sobrenome}</strong> foi redefinida com sucesso. Repasse a senha abaixo ao médico:
+                </p>
+                <div className="gmed__senha-box">{modalSenha.senha}</div>
+                <div className="gmed__modal-actions">
+                  <button className="gmed__modal-btn gmed__modal-btn--cancel" onClick={fecharModalSenha}>
+                    Fechar
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <h2 className="gmed__modal-title">Redefinir senha</h2>
+                <p className="gmed__modal-desc">
+                  Uma nova senha será gerada para <strong>{modalSenha.medico.nome} {modalSenha.medico.sobrenome}</strong>
+                  {modalSenha.medico.crm ? ` (CRM: ${modalSenha.medico.crm})` : ''}.
+                  <br />Repasse a senha ao médico após confirmar.
+                </p>
+                <label className="gmed__modal-label">Nova senha gerada</label>
+                <div className="gmed__senha-box">
+                  {modalSenha.senha}
+                  <button
+                    className="gmed__senha-regenerar"
+                    title="Gerar nova senha"
+                    onClick={() => setModalSenha(m => ({ ...m, senha: gerarSenhaAleatoria() }))}
+                  >
+                    <svg viewBox="0 0 24 24" fill="currentColor" width="15" height="15" aria-hidden="true">
+                      <path d="M17.65 6.35A7.96 7.96 0 0012 4a8 8 0 00-8 8 8 8 0 008 8c3.73 0 6.84-2.55 7.73-6h-2.08A5.99 5.99 0 0112 18a6 6 0 01-6-6 6 6 0 016-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"/>
+                    </svg>
+                  </button>
+                </div>
+
+                {modalSenha.erro && <p className="gmed__modal-erro">{modalSenha.erro}</p>}
+
+                <div className="gmed__modal-actions">
+                  <button
+                    className="gmed__modal-btn gmed__modal-btn--cancel"
+                    onClick={fecharModalSenha}
+                    disabled={modalSenha.loading}
+                  >
+                    Cancelar
+                  </button>
+                  <button
+                    className="gmed__modal-btn gmed__modal-btn--confirm-senha"
+                    onClick={confirmarResetarSenha}
+                    disabled={modalSenha.loading}
+                  >
+                    {modalSenha.loading ? 'Salvando...' : 'Confirmar redefinição'}
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
 
       {modal.open && modal.medico && (
         <div className="gmed__modal-overlay" onClick={fecharModal}>

--- a/frontend/src/layout/Medico/BodyMedico.tsx
+++ b/frontend/src/layout/Medico/BodyMedico.tsx
@@ -32,15 +32,9 @@ const IcAgenda = () => (
 );
 
 const CONSULTAS = [
-  { id:1, paciente:'João Almeida de Castro',  horario:'6:00h',  info:'Informações do Paciente: Relata tosse e secreção' },
-  { id:2, paciente:'Carolina Sato',           horario:'10:20h', info:'Informações do Paciente: Relata tosse e secreção' },
-  { id:3, paciente:'Vinicius Mauro Souza',    horario:'12:00h', info:'Informações do Paciente: Relata tosse e secreção' },
-  { id:4, paciente:'Vinicius Mauro Souza',    horario:'12:00h', info:'Informações do Paciente: Relata tosse e secreção' },
-  { id:5, paciente:'Vinicius Mauro Souza',    horario:'12:00h', info:'Informações do Paciente: Relata tosse e secreção' },
-  { id:6, paciente:'Vinicius Mauro Souza',    horario:'12:00h', info:'Informações do Paciente: Relata tosse e secreção' },
+  
 ];
 
-const hoje = new Date().toLocaleDateString('pt-BR');
 
 interface BodyMedicoProps { nome?: string; crm?: string; }
 
@@ -52,9 +46,7 @@ const BodyMedico: React.FC<BodyMedicoProps> = ({ nome, crm }) => (
     </div>
     <div className="med-acoes">
       {[
-        { Icon: IcMicroscopio, label: 'Solicitar Exame', href: '/' },
         { Icon: IcProntuario,  label: 'Consultar\nProntuário', href: '/prontuario' },
-        { Icon: IcProntuario,  label: 'Consultar\nPacientes', href: '/medico/pacientes' },
         { Icon: IcAgenda,      label: 'Agenda', href: '/' },
       ].map(({ Icon, label, href }) => (
         <a key={label} href={href} className="med-acao-card">
@@ -62,21 +54,6 @@ const BodyMedico: React.FC<BodyMedicoProps> = ({ nome, crm }) => (
           <span>{label}</span>
         </a>
       ))}
-    </div>
-    <div className="med-consultas">
-      <h2 className="med-consultas__titulo">Consultas de hoje - {hoje}</h2>
-      <div className="med-consultas__grid">
-        {CONSULTAS.map(c => (
-          <div key={c.id} className="med-card">
-            <div className="med-card__avatar"><img src="/img/icon.png" alt={c.paciente} /></div>
-            <div className="med-card__info">
-              <p className="med-card__nome">{c.paciente}</p>
-              <p className="med-card__horario">Horário: {c.horario}</p>
-              <p className="med-card__obs">{c.info}</p>
-            </div>
-          </div>
-        ))}
-      </div>
     </div>
   </main>
 );

--- a/frontend/src/layout/Prontuario/BodyProntuario.tsx
+++ b/frontend/src/layout/Prontuario/BodyProntuario.tsx
@@ -119,7 +119,10 @@ ${fileContent}`;
             <p key={label} style={{ margin: 0, fontSize: '0.82rem', lineHeight: 1.5 }}>
               <span style={{ color: '#F5A623', fontWeight: 700 }}>{label}: </span>
               <span style={{ whiteSpace: 'pre-line' }}>{value}</span>
+               <button className="nc-voltar" onClick={() => window.location.href = '/medico'}>Voltar</button> 
+               {/* ESSE BOTAO SERÁ REMOVIDO! */}
             </p>
+            
           ))}
         </div>
       </aside>

--- a/frontend/src/styles/layout/BodyGestorMedicos.css
+++ b/frontend/src/styles/layout/BodyGestorMedicos.css
@@ -194,6 +194,15 @@
   color: #fff;
 }
 
+.gmed__btn-action--senha {
+  background: #e8f0fb;
+  color: #3b6bc8;
+}
+.gmed__btn-action--senha:hover {
+  background: #3b6bc8;
+  color: #fff;
+}
+
 .gmed__btn-action--delete {
   background: #fdecea;
   color: #c0392b;
@@ -309,6 +318,43 @@
   color: #fff;
 }
 .gmed__modal-btn--confirm:hover:not(:disabled) { background: #a93226; }
+
+.gmed__modal-btn--confirm-senha {
+  background: #3b6bc8;
+  color: #fff;
+}
+.gmed__modal-btn--confirm-senha:hover:not(:disabled) { background: #2f58ad; }
+
+.gmed__senha-box {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  background: #f4f8ff;
+  border: 1.5px solid #c0d0ee;
+  border-radius: 8px;
+  padding: 12px 16px;
+  font-family: 'Courier New', monospace;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #1a1a2e;
+  letter-spacing: .08em;
+  word-break: break-all;
+}
+
+.gmed__senha-regenerar {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #3b6bc8;
+  padding: 2px;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 4px;
+  transition: color .2s;
+}
+.gmed__senha-regenerar:hover { color: #2f58ad; }
 
 /* ── RESPONSIVE ── */
 @media (max-width: 991px) {

--- a/frontend/src/styles/layout/BodyMedico.css
+++ b/frontend/src/styles/layout/BodyMedico.css
@@ -5,14 +5,17 @@
   background: linear-gradient(145deg, #0e2a6e 0%, #2458b8 55%, #4d97e4 100%);
   padding: 32px 48px 60px;
   display: flex;
+  justify-content: space-around;
   flex-direction: column;
-  gap: 32px;
+  gap: 10px;
 }
 
 /* Iniciar consulta */
 .med-top {
-  display: flex; align-items: center;
-  justify-content: center; gap: 16px;
+  display: flex; 
+  align-items: center;
+  justify-content: center; 
+  gap: 16px;
 }
 
 .med-iniciar-btn {
@@ -22,7 +25,7 @@
   font-weight: 800;
   font-size: 1rem;
   letter-spacing: .5px;
-  padding: 16px 60px;
+  padding: 16px 150px;
   border-radius: 10px;
   transition: background .2s;
   text-align: center;
@@ -34,7 +37,7 @@
 /* Ações */
 .med-acoes {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(2, 1fr);
   gap: 24px;
   max-width: 900px;
   align-self: center;
@@ -55,44 +58,6 @@
   transition: transform .2s, box-shadow .2s;
 }
 .med-acao-card:hover { transform: translateY(-6px); box-shadow: 0 8px 24px rgba(0,0,0,.15); }
-
-/* Consultas */
-.med-consultas { width: 100%; }
-.med-consultas__titulo {
-  color: #fff;
-  font-size: 1.15rem;
-  font-weight: 700;
-  margin: 0 0 20px;
-}
-.med-consultas__grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 20px;
-}
-
-.med-card {
-  background: #fff;
-  border-radius: 12px;
-  padding: 16px;
-  display: flex; align-items: flex-start; gap: 14px;
-  border: 2px solid #f4a623;
-  transition: transform .2s;
-}
-.med-card:hover { transform: translateY(-3px); }
-
-.med-card__avatar {
-  width: 52px; height: 52px;
-  border-radius: 50%;
-  overflow: hidden;
-  flex-shrink: 0;
-  border: 3px solid #f4a623;
-  background: #fff8e8;
-}
-.med-card__avatar img { width: 100%; height: 100%; object-fit: cover; }
-
-.med-card__nome    { font-weight: 700; font-size: .92rem; color: #1a1a2e; margin: 0 0 3px; }
-.med-card__horario { font-size: .82rem; color: #f4a623; font-weight: 600; margin: 0 0 6px; }
-.med-card__obs     { font-size: .78rem; color: #3b6bc8; font-weight: 500; margin: 0; line-height: 1.4; }
 
 /* ── RESPONSIVE ── */
 @media (max-width: 991px) {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "es5",
     "lib": [
       "dom",


### PR DESCRIPTION
  - Adicionado botão de redefinição de senha na tela de gestão de médicos
  - Ao clicar, abre modal com senha aleatória gerada automaticamente (12 caracteres)
  - Gestor pode regenerar a senha antes de confirmar
  - Confirmação chama PUT /api/auth/resetar-senha com o id do médico e a nova senha
  - Após sucesso, modal exibe a senha final para o gestor repassar ao médico
  - Adicionados estilos para o botão (cadeado azul) e o modal de senha
  - Criado declarations.d.ts para declarar módulos CSS e eliminar os @ts-ignore nos imports
  - Removido dado mock de consultas do BodyMedico
  - Ajuste no tsconfig.json: adicionado ignoreDeprecations 6.0